### PR TITLE
feat(frontend): add setting to make public (aka 0.0.0.0)

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,13 +6,14 @@ load_dotenv()
 from privacy_enabled_agents import PEASettings
 
 
-def run_frontend() -> None:
+def run_frontend(server_name: str) -> None:
     from gradio.blocks import Blocks
 
     from privacy_enabled_agents.frontend.gradio import create_gradio_interface
 
     demo: Blocks = create_gradio_interface()
-    demo.launch(server_name="localhost", server_port=8080)
+
+    demo.launch(server_name=server_name, server_port=8080)
 
 
 def main() -> None:
@@ -23,7 +24,8 @@ def main() -> None:
 
         run_evaluation(settings.evaluation)
     else:
-        run_frontend()
+        server_name: str = "0.0.0.0" if settings.public_frontend else "localhost"
+        run_frontend(server_name)
 
 
 if __name__ == "__main__":

--- a/privacy_enabled_agents/base.py
+++ b/privacy_enabled_agents/base.py
@@ -77,6 +77,10 @@ class PEASettings(BaseSettings):
         default=None,
         description="Link to the poll for feedback.",
     )
+    public_frontend: bool = Field(
+        default=False,
+        description="Whether to make the Gradio frontend publicly accessible.",
+    )
 
     @model_validator(mode="after")
     def validate_eval_config(self) -> Self:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a setting to make the Gradio frontend publicly accessible.
  * The app now respects a configurable server host, allowing binding to 0.0.0.0 for external access or localhost for local-only use.
  * Default behavior remains local-only unless explicitly enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->